### PR TITLE
Put privileged option first

### DIFF
--- a/files/hassio-supervisor
+++ b/files/hassio-supervisor
@@ -24,8 +24,8 @@ runSupervisor() {
     docker rm --force hassio_supervisor || true
 
     # shellcheck disable=SC2086
-    docker run --name hassio_supervisor \
-        --privileged \
+    docker run --privileged \
+        --name hassio_supervisor \
         $APPARMOR \
         --security-opt seccomp=unconfined \
         -v /run/docker.sock:/run/docker.sock \


### PR DESCRIPTION
Having the --privileged option first prevents this error when running unsupported install on ubuntu 20.04, installed through the installer script.
```
CRITICAL (MainThread) [supervisor.misc.hwmon] Not privileged to run udev monitor!
```